### PR TITLE
Update rkernel.py to allow text output on Windows

### DIFF
--- a/rkernel.py
+++ b/rkernel.py
@@ -18,6 +18,7 @@ ip.run_line_magic('config', 'Application.verbose_crash=True')
 old_run_cell = InteractiveShell.run_cell
 
 def run_cell(self, raw_cell, **kw):
-    return old_run_cell(self, '%%R\n' + raw_cell, **kw)
+    old_run_cell(self, '%%R\n..RROUT.. <- capture.output({\n' + raw_cell + '\n})', **kw)
+    return old_run_cell(self, '__RROUT__ = %R ..RROUT..\nfor line in __RROUT__:\n  print(line)\n', **kw)
 
 InteractiveShell.run_cell = run_cell


### PR DESCRIPTION
This is a further hack of Fernando's ipython rkernel.py.  This hack allows ipython notebook on Windows to show text output (ipython/issues/3100).

Enjoy!
